### PR TITLE
Update dhcpadd.pp

### DIFF
--- a/manifests/dhcpadd.pp
+++ b/manifests/dhcpadd.pp
@@ -10,9 +10,9 @@ class windhcp::dhcpadd (
     dsc_windowsfeature { $dsc_resource:
       ensure  => present,
       dsc_name => $dsc_resource,
-
+      before => Exec['set-dhcp-securitygroups'],
     }
-  } ->
+  }
 
 # Add DHCP Security groups
     exec {'set-dhcp-securitygroups':


### PR DESCRIPTION
[5:33 PM] Greg Larkin: @AndyR You likely can't set a dependency arrow on an iterator.
[5:33 PM] Greg Larkin: You would have to use a metaparameter on the resource inside the iterator itself
[5:33 PM] Andy Rajagopalan: oh ok
[5:34 PM] Andy Rajagopalan: thanks @GregLarkin this is how i had it earlier - https://github.com/raj-andy1/control-repo/blob/production/site/windhcp/manifests/dhcpadd.pp
[5:35 PM] Andy Rajagopalan: but i wanted to reduce the number of times i called dsc_windowsfeature
[5:35 PM] Andy Rajagopalan: is there another way of installing multiple features at once
[5:35 PM] Greg Larkin: Do those dsc_windowsfeature resources have to be applied in order?
[5:35 PM] Andy Rajagopalan: no
[5:35 PM] Andy Rajagopalan: but it needs to be applied first before the other stuff can happen
[5:36 PM] Greg Larkin: Ok, so the iterator would work. I think if you added "before => Exec['set-dhcp-securitygroups']" to the resource inside the iterator, both of them would be applied before the exec is applied.
[5:36 PM] Greg Larkin: But they would not depend on each other, but it sounds like that's ok